### PR TITLE
[BEAR-3930]: Enable release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
   "release-it": {
     "git": {
       "commitMessage": "chore: release ${version}",
-      "tagName": "v${version}"
+      "tagName": "v${version}",
+      "requireBranch": "main"
     },
     "npm": {
       "publish": false

--- a/release.sh
+++ b/release.sh
@@ -4,4 +4,4 @@ yarn prepack
 git add lib
 git commit -m "chore: prepack package"
 
-release-it --dry-run
+release-it

--- a/src/NativeHealthConnect.ts
+++ b/src/NativeHealthConnect.ts
@@ -2,7 +2,6 @@ import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 import type { Permission } from './types';
 
-
 type ReadRecordsOptions = {
   startTime: string;
   endTime: string;

--- a/src/types/aggregate.types.ts
+++ b/src/types/aggregate.types.ts
@@ -1,8 +1,4 @@
-import type {
-  MassResult,
-  PressureResult,
-  TimeRangeFilter,
-} from './base.types';
+import type { MassResult, PressureResult, TimeRangeFilter } from './base.types';
 
 interface BaseAggregate {
   dataOrigins: string[];

--- a/src/types/results.types.ts
+++ b/src/types/results.types.ts
@@ -1,7 +1,4 @@
-import type {
-  MassResult,
-  PressureResult,
-} from './base.types';
+import type { MassResult, PressureResult } from './base.types';
 import type {
   BloodPressureRecord,
   BodyTemperatureRecord,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     "strict": true,
     "target": "esnext"
   },
-  "exclude": ["docs"]
+  "exclude": ["docs", "lib"]
 }


### PR DESCRIPTION
This sets up the release script to run properly without the dry run and adds a few extra settings to only allow releases from main and some lint fixes.