### PR TITLE
[BEAR-3935]: Added aggregation by period with only steps supported

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectModule.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectModule.kt
@@ -65,6 +65,11 @@ class HealthConnectModule internal constructor(context: ReactApplicationContext)
     return manager.getChanges(options, promise)
   }
 
+  @ReactMethod
+  override fun readBucketedRecords(recordType: String, options: ReadableMap, promise: Promise) {
+    return manager.readBucketedRecords(recordType, options, promise)
+  }
+
   companion object {
     const val NAME = "HealthConnect"
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
@@ -1,16 +1,23 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BloodPressureRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Pressure
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
+  override fun getResultType(): String {
+    return "PRESSURE"
+  }
+
   override fun parseRecord(record: BloodPressureRecord): WritableNativeMap {
     return WritableNativeMap().apply {
       putString("time", record.time.toString())
@@ -62,6 +69,14 @@ class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
       )
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
     }
+  }
+
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    throw AggregationNotSupported()
   }
 
   private fun bloodPressureToJsMap(pressure: Pressure): WritableNativeMap {

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
@@ -1,12 +1,15 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BodyTemperatureMeasurementLocation
 import androidx.health.connect.client.records.BodyTemperatureRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Temperature
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.InvalidTemperature
@@ -16,6 +19,10 @@ import dev.matinzd.healthconnect.utils.toMapList
 import java.time.Instant
 
 class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> {
+  override fun getResultType(): String {
+    return "BODY_TEMPERATURE"
+  }
+
   override fun parseRecord(record: BodyTemperatureRecord): WritableNativeMap {
     return WritableNativeMap().apply {
       putString("time", record.time.toString())
@@ -30,6 +37,14 @@ class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> 
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
@@ -1,7 +1,9 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.response.InsertRecordsResponse
@@ -63,6 +65,18 @@ class ReactHealthRecord {
       return recordClass.parseAggregationResult(result)
     }
 
+    fun getBucketedRequest(recordType: String, reactRequest: ReadableMap): AggregateGroupByPeriodRequest {
+      val recordClass = createReactHealthRecordInstance<Record>(recordType)
+
+      return recordClass.getBucketedRequest(reactRequest)
+    }
+
+    fun parseBucketedResult(recordType: String, result: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+      val recordClass = createReactHealthRecordInstance<Record>(recordType)
+
+      return recordClass.parseBucketedResult(result)
+    }
+
     fun parseRecords(
       recordType: String,
       response: ReadRecordsResponse<out Record>
@@ -93,6 +107,11 @@ class ReactHealthRecord {
       val reactRecord = reactRecordClass.parseRecord(record)
       reactRecord.putString("recordType", reactClassToReactTypeMap[reactRecordClass.javaClass])
       return reactRecord
+    }
+
+    fun getResultType(recordType: String): String {
+      val recordClass = createReactHealthRecordInstance<Record>(recordType)
+      return recordClass.getResultType()
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
@@ -1,14 +1,20 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 
 interface ReactHealthRecordImpl<T : Record> {
+  fun getResultType(): String
   fun parseRecord(record: T): WritableNativeMap
   fun getAggregateRequest(record: ReadableMap): AggregateRequest
   fun parseAggregationResult(record: AggregationResult): WritableNativeMap
+  fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest
+  fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
@@ -1,7 +1,9 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -11,6 +13,10 @@ import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactHeartRateRecord : ReactHealthRecordImpl<HeartRateRecord> {
+  override fun getResultType(): String {
+    return "HEART"
+  }
+
   override fun parseRecord(record: HeartRateRecord): WritableNativeMap {
     return WritableNativeMap().apply {
       putString("startTime", record.startTime.toString())
@@ -49,5 +55,13 @@ class ReactHeartRateRecord : ReactHealthRecordImpl<HeartRateRecord> {
       putDouble("MEASUREMENTS_COUNT", record[HeartRateRecord.MEASUREMENTS_COUNT]?.toDouble() ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
     }
+  }
+
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataToJSMap
@@ -13,6 +16,10 @@ import java.time.Instant
 
 class ReactHeartRateVariabilityRmssdRecord :
   ReactHealthRecordImpl<HeartRateVariabilityRmssdRecord> {
+  override fun getResultType(): String {
+    return "HEART_RATE_VARIABILITY"
+  }
+
   override fun parseRecord(record: HeartRateVariabilityRmssdRecord): WritableNativeMap {
     return WritableNativeMap().apply {
       putString("time", record.time.toString())
@@ -26,6 +33,14 @@ class ReactHeartRateVariabilityRmssdRecord :
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
@@ -1,15 +1,22 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.RestingHeartRateRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactRestingHeartRateRecord : ReactHealthRecordImpl<RestingHeartRateRecord> {
+  override fun getResultType(): String {
+    return "RESTING_HEART_RATE"
+  }
+
   override fun parseRecord(record: RestingHeartRateRecord): WritableNativeMap {
     return WritableNativeMap().apply {
       putString("time", record.time.toString())
@@ -37,5 +44,13 @@ class ReactRestingHeartRateRecord : ReactHealthRecordImpl<RestingHeartRateRecord
       putDouble("BPM_MIN", record[RestingHeartRateRecord.BPM_MIN]?.toDouble() ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
     }
+  }
+
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
@@ -1,7 +1,9 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -11,6 +13,10 @@ import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
+  override fun getResultType(): String {
+    return "SLEEP"
+  }
+
   override fun parseRecord(record: SleepSessionRecord): WritableNativeMap {
     return WritableNativeMap().apply {
       putString("startTime", record.startTime.toString())
@@ -48,5 +54,13 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
       )
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
     }
+  }
+
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
@@ -1,15 +1,24 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
+import java.time.Period
+import java.time.format.DateTimeFormatter
 
 class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
+  override fun getResultType(): String {
+    return "STEPS"
+  }
+
   override fun parseRecord(record: StepsRecord): WritableNativeMap {
     return WritableNativeMap().apply {
       putString("startTime", record.startTime.toString())
@@ -34,5 +43,41 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
       putDouble("COUNT_TOTAL", record[StepsRecord.COUNT_TOTAL]?.toDouble() ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
     }
+  }
+
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    // get the bucket period and default to 1 day if not provided
+    val bucketPeriod = if (record.hasKey("bucketPeriod")) record.getPeriod("bucketPeriod") else Period.ofDays(1)
+
+    return AggregateGroupByPeriodRequest(
+        metrics = setOf(
+          StepsRecord.COUNT_TOTAL
+        ),
+        timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+        dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter")),
+        timeRangeSlicer = bucketPeriod
+      )
+  }
+
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+        for (daysRecord in records) {
+          // The result may be null if no data is available in the time range
+          val totalSteps = daysRecord.result[StepsRecord.COUNT_TOTAL]
+          // Parse start time in string format YYYYMMDD
+          val date = daysRecord.startTime.format(DateTimeFormatter.BASIC_ISO_DATE)
+
+          if (totalSteps != null) {
+            pushMap(WritableNativeMap().apply {
+              putString("date", date)
+              putMap("entry", WritableNativeMap().apply {
+                putString("type", getResultType())
+                putString("value", totalSteps.toString())
+                putString("family", "HEALTH")
+              })
+            })
+          }
+        }
+      }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
@@ -1,15 +1,22 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.WeightRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
+  override fun getResultType(): String {
+    return "WEIGHT"
+  }
+
   override fun parseRecord(record: WeightRecord): WritableNativeMap {
     return WritableNativeMap().apply {
       putString("time", record.time.toString())
@@ -37,5 +44,13 @@ class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
       putMap("WEIGHT_MIN", massToJsMap(record[WeightRecord.WEIGHT_MIN]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
     }
+  }
+
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.records.*
 import java.time.Instant
+import java.time.Period
 import java.time.ZoneOffset
 import kotlin.reflect.KClass
 
@@ -122,6 +123,18 @@ fun ReadableMap.getTimeRangeFilter(key: String? = null): TimeRangeFilter {
 
       return TimeRangeFilter.between(startTime, endTime)
     }
+  }
+}
+
+fun ReadableMap.getPeriod(key: String): Period {
+  val period = this.getString(key)
+    ?: throw Exception("Period should be provided")
+
+  return when (period) {
+    "day" -> Period.ofDays(1)
+    "month" -> Period.ofMonths(1)
+    "year" -> Period.ofYears(1)
+    else -> throw Exception("Invalid period type")
   }
 }
 

--- a/android/src/oldarch/HealthConnectSpec.kt
+++ b/android/src/oldarch/HealthConnectSpec.kt
@@ -33,5 +33,8 @@ abstract class HealthConnectSpec internal constructor(context: ReactApplicationC
   abstract fun aggregateRecord(record: ReadableMap, promise: Promise);
 
   @ReactMethod
+  abstract fun readBucketedRecords(recordType: String, options: ReadableMap, promise: Promise);
+
+  @ReactMethod
   abstract fun getChanges(options: ReadableMap, promise: Promise);
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,6 +15,8 @@ import {
   Permission,
   RecordType,
   AggregateResultRecordType,
+  readBucketedRecords,
+  RecordTypes,
 } from 'react-native-health-connect';
 
 const getLastWeekDate = (): Date => {
@@ -137,6 +139,22 @@ export default function App() {
     });
   };
 
+  const getBucketedRecords = async (recordType: RecordType) => {
+    try {
+      const result = await readBucketedRecords(recordType, {
+        timeRangeFilter: {
+          operator: 'between',
+          startTime: getLastWeekDate().toISOString(),
+          endTime: getTodayDate().toISOString(),
+        },
+      });
+
+      console.log('result', result);
+    } catch (error) {
+      console.log('error', error);
+    }
+  };
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text>Setup</Text>
@@ -158,16 +176,37 @@ export default function App() {
       <Button title="Get granted permissions" onPress={grantedPermissions} />
       <Button title="Revoke all permissions" onPress={revokeAllPermissions} />
 
+      <Text>Reading bucketed data</Text>
+
+      <Button
+        title="Read bucketed steps"
+        onPress={() => getBucketedRecords('Steps')}
+      />
+
+      {/* Not supported */}
+      <Button
+        title="Read bucketed heart rate"
+        onPress={() => getBucketedRecords('HeartRate')}
+      />
+
       <Text>Reading data</Text>
 
       {availableRecordTypes.map(({ recordType }) => (
-        <Button key={recordType} title={`Read ${recordType} sample data`} onPress={() => readSampleData(recordType)} />
+        <Button
+          key={recordType}
+          title={`Read ${recordType} sample data`}
+          onPress={() => readSampleData(recordType)}
+        />
       ))}
 
       <Text>Reading aggregated data</Text>
 
       {availableAggregateRecordTypes.map((recordType) => (
-        <Button key={recordType} title={`Aggregate ${recordType} sample data`} onPress={() => aggregateSampleData(recordType)} />
+        <Button
+          key={recordType}
+          title={`Aggregate ${recordType} sample data`}
+          onPress={() => aggregateSampleData(recordType)}
+        />
       ))}
     </ScrollView>
   );

--- a/src/NativeHealthConnect.ts
+++ b/src/NativeHealthConnect.ts
@@ -1,17 +1,16 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
-import type { Permission } from './types';
+import type {
+  AggregateRecordResult,
+  BucketedRecordsResult,
+  BucketedRequestOptions,
+  GetChangesResults,
+  Permission,
+  ReadRecordsOptions,
+  ReadRecordsResult,
+  RecordType,
+} from './types';
 
-type ReadRecordsOptions = {
-  startTime: string;
-  endTime: string;
-  dataOriginFilter?: string[];
-  ascendingOrder?: boolean;
-  pageSize?: number;
-  pageToken?: string;
-};
-
-//@TODO: Fix and refactor types when codegen starts supporting type imports and generics
 export interface Spec extends TurboModule {
   getSdkStatus(providerPackageName: string): Promise<number>;
   initialize(providerPackageName: string): Promise<boolean>;
@@ -23,17 +22,24 @@ export interface Spec extends TurboModule {
   ): Promise<Permission[]>;
   getGrantedPermissions(): Promise<Permission[]>;
   revokeAllPermissions(): Promise<void>;
-  readRecords(recordType: string, options: ReadRecordsOptions): Promise<{}>;
+  readRecords(
+    recordType: string,
+    options: ReadRecordsOptions
+  ): Promise<ReadRecordsResult<RecordType>>;
   aggregateRecord(record: {
     recordType: string;
     startTime: string;
     endTime: string;
-  }): Promise<{}>;
+  }): Promise<AggregateRecordResult>;
   getChanges(request: {
     changesToken?: string;
     recordTypes?: string[];
     dataOriginFilters?: string[];
-  }): Promise<{}>;
+  }): Promise<GetChangesResults>;
+  readBucketedRecords(
+    recordType: string,
+    options: BucketedRequestOptions
+  ): Promise<BucketedRecordsResult>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('HealthConnect');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,3 +42,14 @@ export const RecordTypes: Record<string, RecordType> = {
   WEIGHT: 'Weight',
   SLEEP: 'SleepSession',
 } as const;
+
+export const ResultRecordTypes: Record<string, string> = {
+  BODY_TEMPERATURE: 'BODY_TEMPERATURE',
+  HEART_RATE_VARIABILITY: 'HEART_RATE_VARIABILITY',
+  HEART: 'HEART',
+  PRESSURE: 'PRESSURE',
+  RESTING_HEART_RATE: 'RESTING_HEART_RATE',
+  SLEEP: 'SLEEP',
+  STEPS: 'STEPS',
+  WEIGHT: 'WEIGHT',
+} as const;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,9 +9,8 @@ import type {
   ReadRecordsResult,
   GetChangesRequest,
   GetChangesResults,
-  ReadStepRecordsOptions,
-  ReadStepRecordsResult,
   BucketedRequestOptions,
+  BucketedRecordsResult,
 } from './types';
 
 const LINKING_ERROR =
@@ -130,7 +129,7 @@ export function getChanges(
 export function readBucketedRecords(
   recordType: RecordType,
   options: BucketedRequestOptions
-): Promise<ReadStepRecordsResult> {
+): Promise<BucketedRecordsResult> {
   return HealthConnect.readBucketedRecords(recordType, options);
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,9 @@ import type {
   ReadRecordsResult,
   GetChangesRequest,
   GetChangesResults,
+  ReadStepRecordsOptions,
+  ReadStepRecordsResult,
+  BucketedRequestOptions,
 } from './types';
 
 const LINKING_ERROR =
@@ -122,6 +125,13 @@ export function getChanges(
   request: GetChangesRequest
 ): Promise<GetChangesResults> {
   return HealthConnect.getChanges(request);
+}
+
+export function readBucketedRecords(
+  recordType: RecordType,
+  options: BucketedRequestOptions
+): Promise<ReadStepRecordsResult> {
+  return HealthConnect.readBucketedRecords(recordType, options);
 }
 
 export * from './constants';

--- a/src/types/aggregate.types.ts
+++ b/src/types/aggregate.types.ts
@@ -65,3 +65,8 @@ export interface AggregateRequest<T extends AggregateResultRecordType> {
   timeRangeFilter: TimeRangeFilter;
   dataOriginFilter?: string[];
 }
+
+export interface BucketedRequestOptions {
+  timeRangeFilter: TimeRangeFilter;
+  bucketPeriod?: 'day' | 'month' | 'year';
+}

--- a/src/types/results.types.ts
+++ b/src/types/results.types.ts
@@ -10,6 +10,7 @@ import type {
   StepsRecord,
   WeightRecord,
 } from './records.types';
+import { ResultRecordTypes } from '../constants';
 
 type Identity<T> = { [P in keyof T]: T[P] };
 
@@ -68,3 +69,15 @@ export type ReadRecordsResult<T extends RecordType> = {
   records: RecordResult<T>[];
   pageToken?: string;
 };
+
+type ResultRecordType =
+  (typeof ResultRecordTypes)[keyof typeof ResultRecordTypes];
+
+export type BucketedRecordsResult = {
+  dateKey: string;
+  entry: {
+    type: ResultRecordType;
+    value: string;
+    family: 'HEALTH';
+  };
+}[];


### PR DESCRIPTION
## Jira

[📦 Add fetch health data function in package that is called in the new use case](https://bearable-app.atlassian.net/browse/BEAR-3935)

## Description

This adds in a new function to get daily/monthly/yearly aggregated data and returns the type the same as ProcessedData from the client-bearable package. I've tried to reuse a lot of the functionality existing so I've kept request types as similar as possible. I've added the function to the example app so you can see me testing the function out.

## Acceptance criteria

- [x] Update health connect package with steps function that returned processed data

## Safe to release?

My change is safe to release because the function added is not hooked up to any code and you can see that it runs correctly in the recording.

## Screenshots / Recordings

https://github.com/user-attachments/assets/db021306-0737-46e1-822b-396b444f070d

<img width="1186" alt="Screenshot 2024-08-22 at 14 44 28" src="https://github.com/user-attachments/assets/54129a32-3dcb-4cf1-9049-f59036560537">

## Quality

*Have you done the following?*

- Reviewed my own PR
- Handled returned failures or exceptions
- No sensitive data exposed
- Checked typos

- [x] Yes
- [ ] N/A
