### PR TITLE
[BEAR-3936]: Bucketed records timezone fix

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
@@ -10,11 +10,8 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
-import java.time.Instant
 import java.time.Period
 import java.time.format.DateTimeFormatter
-import java.time.ZoneId
-import java.util.TimeZone
 
 class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
   override fun getResultType(): String {
@@ -62,21 +59,12 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
   }
 
   override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
-    // Get the user's timezone from the system
-    val userTimeZone = ZoneId.systemDefault()
-
     return WritableNativeArray().apply {
       for (daysRecord in records) {
         // The result may be null if no data is available in the time range
         val totalSteps = daysRecord.result[StepsRecord.COUNT_TOTAL]
-
-        // If timezone offset is negative use start time else use end time
-        val zonedStartTime = daysRecord.startTime.atZone(userTimeZone).toInstant().toEpochMilli()
-        val offset = TimeZone.getDefault().getOffset(zonedStartTime)
-        val date = if (offset > 0) daysRecord.endTime else daysRecord.startTime
-        
         // Parse date time in string format YYYYMMDD
-        val dateKey = date.format(DateTimeFormatter.BASIC_ISO_DATE)
+        val dateKey = daysRecord.startTime.format(DateTimeFormatter.BASIC_ISO_DATE)
 
         if (totalSteps != null) {
           pushMap(WritableNativeMap().apply {

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -14,8 +14,10 @@ import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.records.*
 import java.time.Instant
+import java.time.LocalDateTime
 import java.time.Period
 import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import kotlin.reflect.KClass
 
 fun <T : Record> convertReactRequestOptionsFromJS(
@@ -89,10 +91,10 @@ fun ReadableMap.getTimeRangeFilter(key: String? = null): TimeRangeFilter {
   val operator = timeRangeFilter.getString("operator")
 
   val startTime =
-    if (timeRangeFilter.hasKey("startTime")) Instant.parse(timeRangeFilter.getString("startTime")) else null
+    if (timeRangeFilter.hasKey("startTime")) LocalDateTime.parse(timeRangeFilter.getString("startTime"), DateTimeFormatter.ISO_DATE_TIME) else null
 
   val endTime =
-    if (timeRangeFilter.hasKey("endTime")) Instant.parse(timeRangeFilter.getString("endTime")) else null
+    if (timeRangeFilter.hasKey("endTime"))  LocalDateTime.parse(timeRangeFilter.getString("endTime"), DateTimeFormatter.ISO_DATE_TIME) else null
 
   when (operator) {
     "between" -> {

--- a/example/package.json
+++ b/example/package.json
@@ -10,17 +10,18 @@
     "pods": "bundle install && pod-install"
   },
   "dependencies": {
+    "moment": "^2.30.1",
     "react": "18.2.0",
     "react-native": "0.73.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "babel-plugin-module-resolver": "^5.0.0",
     "@react-native/babel-preset": "0.73.20",
-    "@react-native/metro-config": "0.73.4",
     "@react-native/eslint-config": "0.73.2",
-    "@react-native/typescript-config": "0.73.1"
+    "@react-native/metro-config": "0.73.4",
+    "@react-native/typescript-config": "0.73.1",
+    "babel-plugin-module-resolver": "^5.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import moment from 'moment';
 
 import { Button, ScrollView, StyleSheet, Text } from 'react-native';
 import {
@@ -140,11 +141,17 @@ export default function App() {
 
   const getBucketedRecords = async (recordType: RecordType) => {
     try {
+      const startTime = moment()
+        .subtract(1, 'week')
+        .startOf('day')
+        .toISOString();
+      const endTime = moment().endOf('day').toISOString();
+
       const result = await readBucketedRecords(recordType, {
         timeRangeFilter: {
           operator: 'between',
-          startTime: getLastWeekDate().toISOString(),
-          endTime: getTodayDate().toISOString(),
+          startTime,
+          endTime,
         },
       });
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -141,11 +141,12 @@ export default function App() {
 
   const getBucketedRecords = async (recordType: RecordType) => {
     try {
+      // Want to keep offset on the iso string to account for timezones
       const startTime = moment()
         .subtract(1, 'week')
         .startOf('day')
-        .toISOString();
-      const endTime = moment().endOf('day').toISOString();
+        .toISOString(true);
+      const endTime = moment().endOf('day').toISOString(true);
 
       const result = await readBucketedRecords(recordType, {
         timeRangeFilter: {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3766,6 +3766,11 @@ mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment@^2.30.1:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
## Description

This fixes a timezone issue where the start date returned wasn't localised and therefore we were getting the wrong date key. This is fixed by using a ISO string with an offset to localise it - it can be given without an offset but this won't take timezones into account. 

## Screenshots / Recordings

Data logged out
```
[
  {
    "dateKey": "20240821",
    "entry": { "family": "HEALTH", "type": "STEPS", "value": "3008" }
  },
  {
    "dateKey": "20240822",
    "entry": { "family": "HEALTH", "type": "STEPS", "value": "42" }
  },
  {
    "dateKey": "20240823",
    "entry": { "family": "HEALTH", "type": "STEPS", "value": "9" }
  },
  {
    "dateKey": "20240827",
    "entry": { "family": "HEALTH", "type": "STEPS", "value": "18" }
  },
  {
    "dateKey": "20240828",
    "entry": { "family": "HEALTH", "type": "STEPS", "value": "15" }
  }
]
```

Data in health connect - for some reason the date in health connect is wrong and is a day behind

<img width="300" src="https://github.com/user-attachments/assets/a58e2ff0-8802-468d-9e28-02d5258623de">
<img width="300" src="https://github.com/user-attachments/assets/b60838c4-7321-4ffa-98c0-d4e9dc667df6">
<img width="300" src="https://github.com/user-attachments/assets/91019e2e-a52d-4a46-be80-4438ba21dac6">
<img width="300" src="https://github.com/user-attachments/assets/d25c33f9-42ec-4749-b1f1-aade568e2bf4">
<img width="300" src="https://github.com/user-attachments/assets/50d3f601-5e97-4d13-b494-d17ecad8894f">

## Quality

*Have you done the following?*

- Reviewed my own PR
- Handled returned failures or exceptions
- No sensitive data exposed
- Checked typos

- [x] Yes
- [ ] N/A