### PR TITLE
[BEAR-3962]: (Health Sync) Update aggregation from period to duration

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
@@ -1,12 +1,9 @@
 package dev.matinzd.healthconnect
 
 import android.content.Intent
-import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.changes.DeletionChange
 import androidx.health.connect.client.changes.UpsertionChange
-import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
-import androidx.health.connect.client.time.TimeRangeFilter
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
@@ -18,15 +15,10 @@ import dev.matinzd.healthconnect.permissions.PermissionUtils
 import dev.matinzd.healthconnect.records.ReactHealthRecord
 import dev.matinzd.healthconnect.utils.ClientNotInitialized
 import dev.matinzd.healthconnect.utils.convertChangesTokenRequestOptionsFromJS
-import dev.matinzd.healthconnect.utils.getTimeRangeFilter
-import dev.matinzd.healthconnect.utils.reactRecordTypeToClassMap
 import dev.matinzd.healthconnect.utils.rejectWithException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.time.Instant
-import java.time.Period
-import java.time.format.DateTimeFormatter
 
 class HealthConnectManager(private val applicationContext: ReactApplicationContext) {
   private lateinit var healthConnectClient: HealthConnectClient
@@ -173,7 +165,7 @@ class HealthConnectManager(private val applicationContext: ReactApplicationConte
       coroutineScope.launch {
         try {
           val request = ReactHealthRecord.getBucketedRequest(recordType, options)
-          val response = healthConnectClient.aggregateGroupByPeriod(request)
+          val response = healthConnectClient.aggregateGroupByDuration(request)
           promise.resolve(ReactHealthRecord.parseBucketedResult(recordType, response))
         } catch (e: Exception) {
           promise.rejectWithException(e)

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
@@ -1,17 +1,15 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
-import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.BloodPressureRecord
-import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Pressure
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
-import java.time.Instant
 
 class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
   override fun getResultType(): String {
@@ -71,11 +69,11 @@ class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
     }
   }
 
-  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByDurationRequest {
     throw AggregationNotSupported()
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
@@ -1,22 +1,16 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
-import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
-import androidx.health.connect.client.records.BodyTemperatureMeasurementLocation
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.BodyTemperatureRecord
-import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Temperature
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
-import dev.matinzd.healthconnect.utils.InvalidTemperature
 import dev.matinzd.healthconnect.utils.convertMetadataToJSMap
-import dev.matinzd.healthconnect.utils.getSafeInt
-import dev.matinzd.healthconnect.utils.toMapList
-import java.time.Instant
 
 class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> {
   override fun getResultType(): String {
@@ -40,11 +34,11 @@ class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> 
     throw AggregationNotSupported()
   }
 
-  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByDurationRequest {
     throw AggregationNotSupported()
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
@@ -1,15 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
-import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.Record
-import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
-import androidx.health.connect.client.response.InsertRecordsResponse
 import androidx.health.connect.client.response.ReadRecordResponse
 import androidx.health.connect.client.response.ReadRecordsResponse
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
@@ -65,13 +63,13 @@ class ReactHealthRecord {
       return recordClass.parseAggregationResult(result)
     }
 
-    fun getBucketedRequest(recordType: String, reactRequest: ReadableMap): AggregateGroupByPeriodRequest {
+    fun getBucketedRequest(recordType: String, reactRequest: ReadableMap): AggregateGroupByDurationRequest {
       val recordClass = createReactHealthRecordInstance<Record>(recordType)
 
       return recordClass.getBucketedRequest(reactRequest)
     }
 
-    fun parseBucketedResult(recordType: String, result: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    fun parseBucketedResult(recordType: String, result: List<AggregationResultGroupedByDuration>): WritableNativeArray {
       val recordClass = createReactHealthRecordInstance<Record>(recordType)
 
       return recordClass.parseBucketedResult(result)

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
@@ -1,11 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
-import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.Record
-import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
@@ -15,6 +14,6 @@ interface ReactHealthRecordImpl<T : Record> {
   fun parseRecord(record: T): WritableNativeMap
   fun getAggregateRequest(record: ReadableMap): AggregateRequest
   fun parseAggregationResult(record: AggregationResult): WritableNativeMap
-  fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest
-  fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray
+  fun getBucketedRequest(record: ReadableMap): AggregateGroupByDurationRequest
+  fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
@@ -1,16 +1,14 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
-import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.HeartRateRecord
-import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
-import java.time.Instant
 
 class ReactHeartRateRecord : ReactHealthRecordImpl<HeartRateRecord> {
   override fun getResultType(): String {
@@ -57,11 +55,11 @@ class ReactHeartRateRecord : ReactHealthRecordImpl<HeartRateRecord> {
     }
   }
 
-  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByDurationRequest {
     throw AggregationNotSupported()
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
@@ -1,18 +1,15 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
-import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
-import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataToJSMap
-import dev.matinzd.healthconnect.utils.toMapList
-import java.time.Instant
 
 class ReactHeartRateVariabilityRmssdRecord :
   ReactHealthRecordImpl<HeartRateVariabilityRmssdRecord> {
@@ -36,11 +33,11 @@ class ReactHeartRateVariabilityRmssdRecord :
     throw AggregationNotSupported()
   }
 
-  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByDurationRequest {
     throw AggregationNotSupported()
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
@@ -1,16 +1,14 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
-import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.RestingHeartRateRecord
-import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
-import java.time.Instant
 
 class ReactRestingHeartRateRecord : ReactHealthRecordImpl<RestingHeartRateRecord> {
   override fun getResultType(): String {
@@ -46,11 +44,11 @@ class ReactRestingHeartRateRecord : ReactHealthRecordImpl<RestingHeartRateRecord
     }
   }
 
-  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByDurationRequest {
     throw AggregationNotSupported()
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
@@ -1,16 +1,14 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
-import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.SleepSessionRecord
-import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
-import java.time.Instant
 
 class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
   override fun getResultType(): String {
@@ -56,11 +54,11 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
     }
   }
 
-  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByDurationRequest {
     throw AggregationNotSupported()
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
@@ -1,17 +1,14 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
-import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.StepsRecord
-import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
-import java.time.Period
-import java.time.format.DateTimeFormatter
 
 class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
   override fun getResultType(): String {
@@ -44,11 +41,11 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
     }
   }
 
-  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
-    // get the bucket period and default to 1 day if not provided
-    val bucketPeriod = if (record.hasKey("bucketPeriod")) record.getPeriod("bucketPeriod") else Period.ofDays(1)
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    // get the bucket period - defaults to 1 day
+    val bucketPeriod = record.getPeriod("bucketPeriod")
 
-    return AggregateGroupByPeriodRequest(
+    return AggregateGroupByDurationRequest(
         metrics = setOf(
           StepsRecord.COUNT_TOTAL
         ),
@@ -58,13 +55,13 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
       )
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     return WritableNativeArray().apply {
       for (daysRecord in records) {
         // The result may be null if no data is available in the time range
         val totalSteps = daysRecord.result[StepsRecord.COUNT_TOTAL]
         // Parse date time in string format YYYYMMDD
-        val dateKey = daysRecord.startTime.format(DateTimeFormatter.BASIC_ISO_DATE)
+        val dateKey = formatDateKey(daysRecord.startTime)
 
         if (totalSteps != null) {
           pushMap(WritableNativeMap().apply {

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
@@ -1,16 +1,14 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
-import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.WeightRecord
-import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
-import java.time.Instant
 
 class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
   override fun getResultType(): String {
@@ -46,11 +44,11 @@ class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
     }
   }
 
-  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+  override fun getBucketedRequest(record: ReadableMap): AggregateGroupByDurationRequest {
     throw AggregationNotSupported()
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -169,11 +169,11 @@ fun convertDeviceToJSMap(device: Device?): WritableNativeMap? {
 }
 
 fun formatDateKey(instant: Instant): String {
-  val zoneTime = ZonedDateTime.ofInstant(instant, ZoneOffset.systemDefault())
-  val dateKey = zoneTime.format(DateTimeFormatter.BASIC_ISO_DATE)
+  val zoneId = ZoneOffset.systemDefault()
+  val zoneTime = ZonedDateTime.ofInstant(instant, zoneId)
 
-  // Remove the offset hours
-  return dateKey.substring(0, 8)
+  val dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+  return zoneTime.format(dateFormatter)
 }
 
 val reactRecordTypeToClassMap: Map<String, KClass<out Record>> = mapOf(

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -13,10 +13,10 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.records.*
+import java.time.Duration
 import java.time.Instant
-import java.time.LocalDateTime
-import java.time.Period
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import kotlin.reflect.KClass
 
@@ -91,10 +91,10 @@ fun ReadableMap.getTimeRangeFilter(key: String? = null): TimeRangeFilter {
   val operator = timeRangeFilter.getString("operator")
 
   val startTime =
-    if (timeRangeFilter.hasKey("startTime")) LocalDateTime.parse(timeRangeFilter.getString("startTime"), DateTimeFormatter.ISO_DATE_TIME) else null
+    if (timeRangeFilter.hasKey("startTime")) Instant.parse(timeRangeFilter.getString("startTime")) else null
 
   val endTime =
-    if (timeRangeFilter.hasKey("endTime"))  LocalDateTime.parse(timeRangeFilter.getString("endTime"), DateTimeFormatter.ISO_DATE_TIME) else null
+    if (timeRangeFilter.hasKey("endTime"))  Instant.parse(timeRangeFilter.getString("endTime")) else null
 
   when (operator) {
     "between" -> {
@@ -128,14 +128,18 @@ fun ReadableMap.getTimeRangeFilter(key: String? = null): TimeRangeFilter {
   }
 }
 
-fun ReadableMap.getPeriod(key: String): Period {
+fun ReadableMap.getPeriod(key: String): Duration {
+  if (!this.hasKey("bucketPeriod")) {
+    return Duration.ofDays(1)
+  }
   val period = this.getString(key)
-    ?: throw Exception("Period should be provided")
+  if (period.isNullOrEmpty()) {
+    return Duration.ofDays(1)
+  }
 
   return when (period) {
-    "day" -> Period.ofDays(1)
-    "month" -> Period.ofMonths(1)
-    "year" -> Period.ofYears(1)
+    "day" -> Duration.ofDays(1)
+    // In future might want to add 'month' & 'year'
     else -> throw Exception("Invalid period type")
   }
 }
@@ -162,6 +166,14 @@ fun convertDeviceToJSMap(device: Device?): WritableNativeMap? {
     putString("manufacturer", device.manufacturer)
     putString("model", device.model)
   }
+}
+
+fun formatDateKey(instant: Instant): String {
+  val zoneTime = ZonedDateTime.ofInstant(instant, ZoneOffset.systemDefault())
+  val dateKey = zoneTime.format(DateTimeFormatter.BASIC_ISO_DATE)
+
+  // Remove the offset hours
+  return dateKey.substring(0, 8)
 }
 
 val reactRecordTypeToClassMap: Map<String, KClass<out Record>> = mapOf(

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -145,8 +145,8 @@ export default function App() {
       const startTime = moment()
         .subtract(1, 'week')
         .startOf('day')
-        .toISOString(true);
-      const endTime = moment().endOf('day').toISOString(true);
+        .toISOString();
+      const endTime = moment().endOf('day').toISOString();
 
       const result = await readBucketedRecords(recordType, {
         timeRangeFilter: {

--- a/src/types/aggregate.types.ts
+++ b/src/types/aggregate.types.ts
@@ -68,5 +68,5 @@ export interface AggregateRequest<T extends AggregateResultRecordType> {
 
 export interface BucketedRequestOptions {
   timeRangeFilter: TimeRangeFilter;
-  bucketPeriod?: 'day' | 'month' | 'year';
+  bucketPeriod?: 'day'; // In future 'month' | 'year';
 }


### PR DESCRIPTION
## Jira

[🥾 I want to be able to sync my steps using Health Connect](https://bearable-app.atlassian.net/browse/BEAR-3962)

## Description

This PR looks at fixing the timezone issues we were seeing with steps data. The issue seemed to be with the request that I was performing as health connect has two similar ones that aggregate by Duration or Period. The documentation isn't very clear with the difference but the Period one doesn't return Instant times which means timezones aren't really considered. Duration is a set period of time so things might get a little messed up around days with daylight savings sometimes however this function seemed much more reliable than the Period one - might be worth a quick chat to discuss the pros/cons of this change. I had to remove month and year as bucket period lengths as the duration doesn't handle this and it would have to be requested with period.

## Acceptance criteria

- [x] Make sure data syncs correctly within different timezones

## Safe to release?

My change is safe to release because it's not hooked up to any public code in bearable.

## Figma designs

N/A

## Screenshots / Recordings

### Add data in London (+1)

https://github.com/user-attachments/assets/e9db1a84-c521-4e45-a226-3f4ee8b368a4

### Add data in Honolulu (-10)

https://github.com/user-attachments/assets/2d466e44-169d-4e9c-a07a-4edf1e40d0eb

### Add data in Tokyo (+9)

https://github.com/user-attachments/assets/c5fb6acc-5e89-4341-8c5b-8c01bb6838aa

## Quality

*Have you done the following?*

- Reviewed my own PR
- Handled returned failures or exceptions
- No sensitive data exposed
- Checked typos

- [x] Yes
- [ ] N/A

## Jira

*Have you done the following?*

- User testing steps
- `🟢-SAFE-TO-RELEASE` or `🔴-NOT-SAFE-TO-RELEASE` label

- [ ] Yes
- [x] N/A - will need to update the bearable side so will do this then
