### PR TITLE
[BEAR-4133]: Bucketed weight

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
@@ -166,7 +166,7 @@ class HealthConnectManager(private val applicationContext: ReactApplicationConte
         try {
           val request = ReactHealthRecord.getBucketedRequest(recordType, options)
           val response = healthConnectClient.aggregateGroupByDuration(request)
-          promise.resolve(ReactHealthRecord.parseBucketedResult(recordType, response))
+          promise.resolve(ReactHealthRecord.parseBucketedResult(recordType, response, options))
         } catch (e: Exception) {
           promise.rejectWithException(e)
         }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
@@ -73,7 +73,7 @@ class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
     throw AggregationNotSupported()
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
@@ -5,12 +5,14 @@ import androidx.health.connect.client.aggregate.AggregationResultGroupedByDurati
 import androidx.health.connect.client.records.BodyTemperatureRecord
 import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
+import androidx.health.connect.client.units.Mass
 import androidx.health.connect.client.units.Temperature
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataToJSMap
+import dev.matinzd.healthconnect.utils.formatDoubleAsString
 
 class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> {
   override fun getResultType(): String {
@@ -38,7 +40,7 @@ class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> 
     throw AggregationNotSupported()
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
@@ -69,10 +69,10 @@ class ReactHealthRecord {
       return recordClass.getBucketedRequest(reactRequest)
     }
 
-    fun parseBucketedResult(recordType: String, result: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    fun parseBucketedResult(recordType: String, result: List<AggregationResultGroupedByDuration>, reactRequest: ReadableMap): WritableNativeArray {
       val recordClass = createReactHealthRecordInstance<Record>(recordType)
 
-      return recordClass.parseBucketedResult(result)
+      return recordClass.parseBucketedResult(result, reactRequest)
     }
 
     fun parseRecords(

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
@@ -14,6 +14,6 @@ interface ReactHealthRecordImpl<T : Record> {
   fun parseRecord(record: T): WritableNativeMap
   fun getAggregateRequest(record: ReadableMap): AggregateRequest
   fun parseAggregationResult(record: AggregationResult): WritableNativeMap
-  fun getBucketedRequest(record: ReadableMap): AggregateGroupByDurationRequest
-  fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray
+  fun getBucketedRequest(options: ReadableMap): AggregateGroupByDurationRequest
+  fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
@@ -71,7 +71,7 @@ class ReactHeartRateRecord : ReactHealthRecordImpl<HeartRateRecord> {
     )
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray {
     return WritableNativeArray().apply {
       for (daysRecord in records) {
         // The result may be null if no data is available in the time range

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
@@ -37,7 +37,7 @@ class ReactHeartRateVariabilityRmssdRecord :
     throw AggregationNotSupported()
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
@@ -59,7 +59,7 @@ class ReactRestingHeartRateRecord : ReactHealthRecordImpl<RestingHeartRateRecord
       )
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray {
     return WritableNativeArray().apply {
       for (daysRecord in records) {
         // The result may be null if no data is available in the time range

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
@@ -58,7 +58,7 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
     throw AggregationNotSupported()
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
@@ -55,7 +55,7 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
       )
   }
 
-  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+  override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray {
     return WritableNativeArray().apply {
       for (daysRecord in records) {
         // The result may be null if no data is available in the time range

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -145,6 +145,14 @@ fun ReadableMap.getPeriod(key: String): Duration {
   }
 }
 
+fun ReadableMap.getUnits(key: String? = null): String? {
+  val optionKey = key ?: "unit"
+  if (!this.hasKey(optionKey)) {
+    return null
+  }
+  return this.getString(optionKey)
+}
+
 fun convertMetadataToJSMap(meta: Metadata): WritableNativeMap {
   return WritableNativeMap().apply {
     putString("id", meta.id)
@@ -178,6 +186,11 @@ fun formatDateKey(instant: Instant): String {
 }
 
 fun formatLongAsString(value: Long): String {
+  val formatter = DecimalFormat("#.##")
+  return formatter.format(value)
+}
+
+fun formatDoubleAsString(value: Double): String {
   val formatter = DecimalFormat("#.##")
   return formatter.format(value)
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -18,6 +18,7 @@ import {
   AggregateResultRecordType,
   readBucketedRecords,
 } from 'react-native-health-connect';
+import { HealthUnit } from 'src/types/base.types';
 
 const getLastWeekDate = (): Date => {
   return new Date(new Date().getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -75,10 +76,12 @@ const availableAggregateRecordTypes: AggregateResultRecordType[] = [
   'SleepSession',
 ];
 
-const availableBucketedTypes: RecordType[] = [
-  'Steps',
-  'HeartRate',
-  'RestingHeartRate',
+const availableBucketedTypes: { type: RecordType; units?: HealthUnit }[] = [
+  { type: 'Steps' },
+  { type: 'HeartRate' },
+  { type: 'RestingHeartRate' },
+  { type: 'Weight', units: 'kg' },
+  { type: 'Weight', units: 'pound' },
 ];
 
 export default function App() {
@@ -145,7 +148,10 @@ export default function App() {
     });
   };
 
-  const getBucketedRecords = async (recordType: RecordType) => {
+  const getBucketedRecords = async (
+    recordType: RecordType,
+    unit?: HealthUnit
+  ) => {
     try {
       // Want to keep offset on the iso string to account for timezones
       const startTime = moment()
@@ -160,6 +166,7 @@ export default function App() {
           startTime,
           endTime,
         },
+        unit,
       });
 
       console.log('result', result);
@@ -195,11 +202,11 @@ export default function App() {
 
       <Text>Reading bucketed data</Text>
 
-      {availableBucketedTypes.map((recordType) => (
+      {availableBucketedTypes.map(({ type, units }) => (
         <Button
-          key={recordType}
-          title={`Read bucketed ${recordType}`}
-          onPress={() => getBucketedRecords(recordType)}
+          key={`${type}-${units}`}
+          title={`Read bucketed ${type}${units ? `(${units})` : ''}`}
+          onPress={() => getBucketedRecords(type, units)}
         />
       ))}
 

--- a/src/types/aggregate.types.ts
+++ b/src/types/aggregate.types.ts
@@ -1,4 +1,9 @@
-import type { MassResult, PressureResult, TimeRangeFilter } from './base.types';
+import type {
+  HealthUnit,
+  MassResult,
+  PressureResult,
+  TimeRangeFilter,
+} from './base.types';
 
 interface BaseAggregate {
   dataOrigins: string[];
@@ -69,4 +74,5 @@ export interface AggregateRequest<T extends AggregateResultRecordType> {
 export interface BucketedRequestOptions {
   timeRangeFilter: TimeRangeFilter;
   bucketPeriod?: 'day'; // In future 'month' | 'year';
+  unit?: HealthUnit;
 }

--- a/src/types/base.types.ts
+++ b/src/types/base.types.ts
@@ -77,3 +77,5 @@ export interface SleepStage {
   // Use SleepStageType constant
   stage: number;
 }
+
+export type HealthUnit = 'celsius' | 'fahrenheit' | 'mmhg' | 'kg' | 'pound';


### PR DESCRIPTION
This PR adds the ability to get bucketed weights. For weight there is now the ability to select which unit you'd like it to be returned in. Unfortunately health connect isn't as flexible as ios so we can only get the average weight for the day rather than the latest value.

This is safe to merge as it is not hooked up to any bearable functionality.

https://github.com/user-attachments/assets/d2d16fda-b520-47d7-a91d-48747b6fd389

