### PR TITLE
[BEAR-4134]: Added sleep to be bucketed using manually bucket function

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
@@ -173,5 +173,19 @@ class HealthConnectManager(private val applicationContext: ReactApplicationConte
       }
     }
   }
+
+  fun readManuallyBucketedRecords(recordType: String, options: ReadableMap, promise: Promise) {
+    throwUnlessClientIsAvailable(promise) {
+      coroutineScope.launch {
+        try {
+          val request = ReactHealthRecord.parseReadRequest(recordType, options)
+          val response = healthConnectClient.readRecords(request)
+          promise.resolve(ReactHealthRecord.parseManuallyBucketedResult(recordType, response.records, options))
+        } catch (e: Exception) {
+          promise.rejectWithException(e)
+        }
+      }
+    }
+  }
 }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectModule.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectModule.kt
@@ -70,6 +70,11 @@ class HealthConnectModule internal constructor(context: ReactApplicationContext)
     return manager.readBucketedRecords(recordType, options, promise)
   }
 
+  @ReactMethod
+  override fun readManuallyBucketedRecords(recordType: String, options: ReadableMap, promise: Promise) {
+    return manager.readManuallyBucketedRecords(recordType, options, promise)
+  }
+
   companion object {
     const val NAME = "HealthConnect"
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
@@ -77,6 +77,10 @@ class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun parseManuallyBucketedResult(records: List<BloodPressureRecord>, options: ReadableMap): WritableNativeArray {
+    throw AggregationNotSupported()
+  }
+
   private fun bloodPressureToJsMap(pressure: Pressure): WritableNativeMap {
     return WritableNativeMap().apply {
       putDouble("inMillimetersOfMercury", pressure.inMillimetersOfMercury)

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
@@ -5,14 +5,12 @@ import androidx.health.connect.client.aggregate.AggregationResultGroupedByDurati
 import androidx.health.connect.client.records.BodyTemperatureRecord
 import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
-import androidx.health.connect.client.units.Mass
 import androidx.health.connect.client.units.Temperature
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataToJSMap
-import dev.matinzd.healthconnect.utils.formatDoubleAsString
 
 class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> {
   override fun getResultType(): String {
@@ -41,6 +39,10 @@ class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> 
   }
 
   override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseManuallyBucketedResult(records: List<BodyTemperatureRecord>, options: ReadableMap): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
@@ -75,6 +75,12 @@ class ReactHealthRecord {
       return recordClass.parseBucketedResult(result, reactRequest)
     }
 
+    fun parseManuallyBucketedResult(recordType: String, result: List<Record>, reactRequest: ReadableMap): WritableNativeArray {
+      val recordClass = createReactHealthRecordInstance<Record>(recordType)
+
+      return recordClass.parseManuallyBucketedResult(result, reactRequest)
+    }
+
     fun parseRecords(
       recordType: String,
       response: ReadRecordsResponse<out Record>

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
@@ -16,4 +16,5 @@ interface ReactHealthRecordImpl<T : Record> {
   fun parseAggregationResult(record: AggregationResult): WritableNativeMap
   fun getBucketedRequest(options: ReadableMap): AggregateGroupByDurationRequest
   fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray
+  fun parseManuallyBucketedResult(records: List<T>, options: ReadableMap): WritableNativeArray
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
@@ -87,4 +87,8 @@ class ReactHeartRateRecord : ReactHealthRecordImpl<HeartRateRecord> {
       }
     }
   }
+
+  override fun parseManuallyBucketedResult(records: List<HeartRateRecord>, options: ReadableMap): WritableNativeArray {
+    throw AggregationNotSupported()
+  }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
@@ -40,4 +40,8 @@ class ReactHeartRateVariabilityRmssdRecord :
   override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray {
     throw AggregationNotSupported()
   }
+
+  override fun parseManuallyBucketedResult(records: List<HeartRateVariabilityRmssdRecord>, options: ReadableMap): WritableNativeArray {
+    throw AggregationNotSupported()
+  }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
@@ -3,7 +3,6 @@ package dev.matinzd.healthconnect.records
 import androidx.health.connect.client.aggregate.AggregationResult
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.RestingHeartRateRecord
-import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableMap
@@ -72,5 +71,9 @@ class ReactRestingHeartRateRecord : ReactHealthRecordImpl<RestingHeartRateRecord
         }
       }
     }
+  }
+
+  override fun parseManuallyBucketedResult(records: List<RestingHeartRateRecord>, options: ReadableMap): WritableNativeArray {
+    throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
@@ -9,6 +9,26 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
+import java.time.Duration
+import java.time.Instant
+
+enum class SleepType {
+  IN_BED, ASLEEP, AWAKE
+}
+
+data class SimpleSleepSample(
+  val startDate: Instant,
+  val endDate: Instant,
+  val type: SleepType
+)
+
+data class SleepValue(
+  var duration: Double,
+  var inBed: Instant? = null,
+  var outOfBed: Instant? = null,
+  var fellAsleep: Instant? = null,
+  var wokeUp: Instant? = null
+)
 
 class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
   override fun getResultType(): String {
@@ -60,5 +80,129 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
 
   override fun parseBucketedResult(records: List<AggregationResultGroupedByDuration>, options: ReadableMap): WritableNativeArray {
     throw AggregationNotSupported()
+  }
+
+  override fun parseManuallyBucketedResult(records: List<SleepSessionRecord>, options: ReadableMap): WritableNativeArray {
+    var sampleDict: MutableMap<String, MutableMap<SleepType, MutableList<SimpleSleepSample>>> = mutableMapOf()
+    val cutOffHour = options.getHourFromTimeRange()
+
+    for (daysRecord in records) {
+      // If no stages then this is a manual sleep entry so we create new list with one stage
+      // Have to map like this as we can't create a sleep stage as they're only available API 34+
+      val stages: List<SimpleSleepSample> = daysRecord.stages.map {
+        stage: SleepSessionRecord.Stage -> SimpleSleepSample(
+          stage.startTime,
+          stage.endTime,
+          convertRecordToSleepType(stage.stage)
+        )
+      }.ifEmpty {
+        listOf(SimpleSleepSample(
+          daysRecord.startTime,
+          daysRecord.endTime,
+          SleepType.ASLEEP
+        ))
+      }
+
+      for (stage in stages) {
+        val dateKey = formatSleepDateKey(stage.startDate, cutOffHour)
+        val sleepType = stage.type
+        if (sleepType == SleepType.AWAKE) {
+          continue
+        }
+
+        val sleepTypeDict = sampleDict.getOrPut(dateKey) { mutableMapOf() }
+        val samplesForType = sleepTypeDict.getOrPut(sleepType) { mutableListOf() }
+
+        var newSample = SimpleSleepSample(
+          stage.startDate,
+          stage.endDate,
+          sleepType
+        )
+
+        // Check if there's an overlap with the last sample in the list
+        if (samplesForType.isNotEmpty()) {
+          val lastSample = samplesForType.last()
+
+          // If the last sample's endDate is greater than the new sample's startDate, we have an overlap
+          if (lastSample.endDate.isAfter(newSample.startDate)) {
+            // Full overlap: skip if the last sample's endDate is greater than or equal to the new sample's endDate
+            if (lastSample.endDate.isAfter(newSample.endDate) || lastSample.endDate == newSample.endDate) {
+              continue
+            }
+
+            // Partial overlap: Adjust the new sample's startDate to the last sample's startDate
+            newSample = newSample.copy(startDate = lastSample.startDate)
+            samplesForType.removeLast()
+          }
+        }
+        samplesForType.add(newSample)
+        sleepTypeDict[sleepType] = samplesForType
+        sampleDict[dateKey] = sleepTypeDict
+      }
+    }
+
+    return WritableNativeArray().apply {
+      for (dayEntry in sampleDict.entries) {
+        val dateKey = dayEntry.key
+        var sleepValue = SleepValue(
+          duration = 0.0,
+          inBed = null,
+          outOfBed = null,
+          fellAsleep = null,
+          wokeUp = null,
+        )
+
+        for (entries in dayEntry.value.entries) {
+          for (entry in entries.value) {
+            when (entries.key) {
+              SleepType.IN_BED -> {
+                sleepValue.inBed = if (sleepValue.inBed != null && sleepValue.inBed!!.isBefore(entry.startDate)) {
+                  sleepValue.inBed
+                } else {
+                  entry.startDate
+                }
+                sleepValue.outOfBed = if (sleepValue.outOfBed != null && sleepValue.outOfBed!!.isBefore(entry.endDate)) {
+                  sleepValue.outOfBed
+                } else {
+                  entry.endDate
+                }
+              }
+              SleepType.ASLEEP -> {
+                sleepValue.fellAsleep = if (sleepValue.fellAsleep != null && sleepValue.fellAsleep!!.isBefore(entry.startDate)) {
+                  sleepValue.fellAsleep
+                } else {
+                  entry.startDate
+                }
+                sleepValue.wokeUp = if (sleepValue.wokeUp != null && sleepValue.wokeUp!!.isBefore(entry.endDate)) {
+                  sleepValue.wokeUp
+                } else {
+                  entry.endDate
+                }
+
+                sleepValue.duration += Duration.between(sleepValue.fellAsleep, sleepValue.wokeUp).seconds
+              }
+              else -> {}
+            }
+          }
+        }
+
+        val record = formatSleepRecord(dateKey, getResultType(), sleepValue)
+        pushMap(record)
+      }
+    }
+  }
+
+  private fun convertRecordToSleepType(stage: Int): SleepType {
+    return when (stage) {
+      SleepSessionRecord.STAGE_TYPE_AWAKE -> SleepType.AWAKE
+      SleepSessionRecord.STAGE_TYPE_OUT_OF_BED -> SleepType.AWAKE
+      SleepSessionRecord.STAGE_TYPE_UNKNOWN -> SleepType.AWAKE
+      SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED -> SleepType.IN_BED
+      SleepSessionRecord.STAGE_TYPE_DEEP -> SleepType.ASLEEP
+      SleepSessionRecord.STAGE_TYPE_LIGHT -> SleepType.ASLEEP
+      SleepSessionRecord.STAGE_TYPE_REM -> SleepType.ASLEEP
+      SleepSessionRecord.STAGE_TYPE_SLEEPING -> SleepType.ASLEEP
+      else -> SleepType.ASLEEP
+    }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
@@ -178,8 +178,7 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
                 } else {
                   entry.endDate
                 }
-
-                sleepValue.duration += Duration.between(sleepValue.fellAsleep, sleepValue.wokeUp).seconds
+                sleepValue.duration += Duration.between(entry.startDate, entry.endDate).seconds
               }
               else -> {}
             }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
@@ -69,4 +69,8 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
       }
     }
   }
+
+  override fun parseManuallyBucketedResult(records: List<StepsRecord>, options: ReadableMap): WritableNativeArray {
+    throw AggregationNotSupported()
+  }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
@@ -76,6 +76,10 @@ class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
     }
   }
 
+  override fun parseManuallyBucketedResult(records: List<WeightRecord>, options: ReadableMap): WritableNativeArray {
+    throw AggregationNotSupported()
+  }
+
   private fun convertMassToValue(mass: Mass, unit: String?): String {
     var value: Double = when (unit) {
       "kg" -> mass.inKilograms

--- a/android/src/oldarch/HealthConnectSpec.kt
+++ b/android/src/oldarch/HealthConnectSpec.kt
@@ -36,5 +36,8 @@ abstract class HealthConnectSpec internal constructor(context: ReactApplicationC
   abstract fun readBucketedRecords(recordType: String, options: ReadableMap, promise: Promise);
 
   @ReactMethod
+  abstract fun readManuallyBucketedRecords(recordType: String, options: ReadableMap, promise: Promise);
+
+  @ReactMethod
   abstract fun getChanges(options: ReadableMap, promise: Promise);
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -82,6 +82,7 @@ const availableBucketedTypes: { type: RecordType; units?: HealthUnit }[] = [
   { type: 'RestingHeartRate' },
   { type: 'Weight', units: 'kg' },
   { type: 'Weight', units: 'pound' },
+  { type: 'SleepSession' },
 ];
 
 export default function App() {
@@ -153,18 +154,20 @@ export default function App() {
     unit?: HealthUnit
   ) => {
     try {
-      // Want to keep offset on the iso string to account for timezones
-      const startTime = moment()
-        .subtract(1, 'week')
-        .startOf('day')
-        .toISOString();
-      const endTime = moment().endOf('day').toISOString();
+      const startTime = moment().subtract(1, 'week').startOf('day');
+      const endTime = moment().endOf('day');
 
       const result = await readBucketedRecords(recordType, {
         timeRangeFilter: {
           operator: 'between',
-          startTime,
-          endTime,
+          startTime:
+            recordType === 'SleepSession'
+              ? startTime.subtract(12, 'h').toISOString()
+              : startTime.toISOString(),
+          endTime:
+            recordType === 'SleepSession'
+              ? endTime.subtract(12, 'h').toISOString()
+              : endTime.toISOString(),
         },
         unit,
       });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -130,6 +130,19 @@ export function readBucketedRecords(
   recordType: RecordType,
   options: BucketedRequestOptions
 ): Promise<BucketedRecordsResult> {
+  // These types aren't currently supported by the aggregateByDuration sdk method
+  // TODO: Handle blood pressure aggregate only available on Android 15+
+  if (
+    [
+      'BloodPressure',
+      'BodyTemperature',
+      'HeartRateVariabilityRmssd',
+      'SleepSession',
+    ].includes(recordType)
+  ) {
+    return HealthConnect.readManuallyBucketedRecords(recordType, options);
+  }
+
   return HealthConnect.readBucketedRecords(recordType, options);
 }
 


### PR DESCRIPTION
## Description

This PR adds the ability to fetch bucketed sleep records. I discovered last week that a few other types aren't available to use the aggregation query which means we'll have to do this manually in the native code, hence why I've set up sleep under the same bucketed function and separate via the javascript which native function it hits. Happy to hear other suggestions on how best to structure.

I've basically converted the iOS code to Kotlin, the main difference is how the native sample/record is structured. Health connect provides a record with different stages included in it. When you create a manually entry then no stages are provided. You should be able to see I default the list if the stages are empty. Unfortunately I haven't got any stage data at the moment so I plan to use the fitbit tonight to get some data. It's possible I'll need to make some tweaks to this in the future with more data.

It's safe to merge because it's not currently hooked up to the bearable code.

https://github.com/user-attachments/assets/7c83cdf4-748d-4ce7-8512-24ac803a5ec8