### PR TITLE
[BEAR-4137|BEAR-4136]: Bucketed heart rate variability and body temp

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
@@ -11,6 +11,10 @@ import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataToJSMap
+import dev.matinzd.healthconnect.utils.formatDateKey
+import dev.matinzd.healthconnect.utils.formatNumberAsString
+import dev.matinzd.healthconnect.utils.formatRecord
+import dev.matinzd.healthconnect.utils.getUnits
 
 class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> {
   override fun getResultType(): String {
@@ -43,7 +47,36 @@ class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> 
   }
 
   override fun parseManuallyBucketedResult(records: List<BodyTemperatureRecord>, options: ReadableMap): WritableNativeArray {
-    throw AggregationNotSupported()
+    var recordsByDate: MutableMap<String, MutableList<BodyTemperatureRecord>> = mutableMapOf()
+    val units = options.getUnits()
+
+    // Group by date
+    for (record in records) {
+      val dateKey = formatDateKey(record.time)
+      val recordsForDate = recordsByDate.getOrPut(dateKey) { mutableListOf() }
+      recordsForDate.add(record)
+    }
+
+    return WritableNativeArray().apply {
+      // Create aggregate value
+      for (recordsForDate in recordsByDate.entries) {
+        val dateKey = recordsForDate.key
+        val tempRecords = recordsForDate.value
+        val totalTemp = tempRecords.fold(0.0) { acc: Double, record: BodyTemperatureRecord -> acc + convertTempToValue(record.temperature, units) }
+        val value = formatNumberAsString(totalTemp / tempRecords.size)
+
+        val record = formatRecord(dateKey, getResultType(), value)
+        pushMap(record)
+      }
+    }
+  }
+
+  private fun convertTempToValue(temp: Temperature, unit: String?): Double {
+    return when (unit) {
+      "celsius" -> temp.inCelsius
+      "fahrenheit" -> temp.inFahrenheit
+      else -> temp.inCelsius
+    }
   }
 
   private fun temperatureToJsMap(temperature: Temperature): WritableNativeMap {

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
@@ -80,7 +80,7 @@ class ReactHeartRateRecord : ReactHealthRecordImpl<HeartRateRecord> {
         val hrMax = daysRecord.result[HeartRateRecord.BPM_MAX]
 
         if (hrMin != null && hrAvg != null && hrMax != null) {
-          val value = "${formatLongAsString(hrMin)}/${formatLongAsString(hrAvg)}/${formatLongAsString(hrMax)}"
+          val value = "${formatNumberAsString(hrMin)}/${formatNumberAsString(hrAvg)}/${formatNumberAsString(hrMax)}"
           val record = formatRecord(daysRecord.startTime, getResultType(), value)
           pushMap(record)
         }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
@@ -65,7 +65,7 @@ class ReactRestingHeartRateRecord : ReactHealthRecordImpl<RestingHeartRateRecord
         val restingHRAvg = daysRecord.result[RestingHeartRateRecord.BPM_AVG]
 
         if (restingHRAvg != null) {
-          val value = formatLongAsString(restingHRAvg)
+          val value = formatNumberAsString(restingHRAvg)
           val record = formatRecord(daysRecord.startTime, getResultType(), value)
           pushMap(record)
         }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
@@ -62,7 +62,7 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
         val totalSteps = daysRecord.result[StepsRecord.COUNT_TOTAL]
 
         if (totalSteps != null) {
-          val value = formatLongAsString(totalSteps)
+          val value = formatNumberAsString(totalSteps)
           val record = formatRecord(daysRecord.startTime, getResultType(), value)
           pushMap(record)
         }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
@@ -87,6 +87,6 @@ class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
       else -> mass.inKilograms
     }
 
-    return formatDoubleAsString(value)
+    return formatNumberAsString(value)
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -215,12 +215,12 @@ fun formatSleepDateKey(instant: Instant, cutOff: Int): String {
   return formatDateKey(finalInstant)
 }
 
-fun formatLongAsString(value: Long): String {
+fun formatNumberAsString(value: Long): String {
   val formatter = DecimalFormat("#.##")
   return formatter.format(value)
 }
 
-fun formatDoubleAsString(value: Double): String {
+fun formatNumberAsString(value: Double): String {
   val formatter = DecimalFormat("#.##")
   return formatter.format(value)
 }
@@ -236,6 +236,17 @@ fun formatDuration(seconds: Double): String {
 fun formatRecord(date: Instant, type: String, value: String): WritableNativeMap {
   return WritableNativeMap().apply {
     putString("dateKey", formatDateKey(date))
+    putMap("entry", WritableNativeMap().apply {
+      putString("type", type)
+      putString("value", value)
+      putString("family", "HEALTH")
+    })
+  }
+}
+
+fun formatRecord(date: String, type: String, value: String): WritableNativeMap {
+  return WritableNativeMap().apply {
+    putString("dateKey", date)
     putMap("entry", WritableNativeMap().apply {
       putString("type", type)
       putString("value", value)

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -83,6 +83,9 @@ const availableBucketedTypes: { type: RecordType; units?: HealthUnit }[] = [
   { type: 'Weight', units: 'kg' },
   { type: 'Weight', units: 'pound' },
   { type: 'SleepSession' },
+  { type: 'BodyTemperature', units: 'celsius' },
+  { type: 'BodyTemperature', units: 'fahrenheit' },
+  { type: 'HeartRateVariabilityRmssd' },
 ];
 
 export default function App() {


### PR DESCRIPTION
## Description

These two types aren't supported by the aggregate query so I've used the manual function I added for the sleep one to find the average manually based on all records. I've updated a couple of the util functions to handle different types. Unfortunately I can't add heart rate variability manually so will need to try and get some over the coming days using the fitbit.

This is safe to release as it's not hooked up to any bearable code.

https://github.com/user-attachments/assets/06db7ee8-e120-4d14-b700-f79f6dd69d16
