### PR TITLE
fix: updated reference to removeLast

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
@@ -129,7 +129,7 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
 
             // Partial overlap: Adjust the new sample's startDate to the last sample's startDate
             newSample = stage.copy(startDate = lastSample.startDate)
-            samplesForType.removeLast()
+            samplesForType.removeAt(samplesForType.lastIndex)
           }
         }
         samplesForType.add(newSample)


### PR DESCRIPTION
This fixes an error with the package that uses functions which conflict with android 15 so I've updated them as advised.

<img width="2938" height="836" alt="image" src="https://github.com/user-attachments/assets/7cdbef85-ebb6-4511-9cb8-2b41b5aeb585" />

I haven't been able to test this with actual data as the historic permission means I can't see the sleep data I have. I was planning to test this with Julian.