### PR TITLE
Add definition to turbo modules

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectModule.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectModule.kt
@@ -80,7 +80,7 @@ class HealthConnectModule internal constructor(context: ReactApplicationContext)
   }
 
   @ReactMethod
-  fun readManuallyBucketedRecords(recordType: String, options: ReadableMap, promise: Promise) {
+  override fun readManuallyBucketedRecords(recordType: String, options: ReadableMap, promise: Promise) {
     return manager.readManuallyBucketedRecords(recordType, options, promise)
   }
 

--- a/src/NativeHealthConnect.ts
+++ b/src/NativeHealthConnect.ts
@@ -82,6 +82,27 @@ export interface Spec extends TurboModule {
       unit?: 'celsius' | 'fahrenheit' | 'kg' | 'pound';
     }
   ): Promise<BucketedRecordsResult>;
+  readManuallyBucketedRecords(
+    recordType: string,
+    options: {
+      timeRangeFilter:
+        | {
+            operator: 'between';
+            startTime: string;
+            endTime: string;
+          }
+        | {
+            operator: 'after';
+            startTime: string;
+          }
+        | {
+            operator: 'before';
+            endTime: string;
+          };
+      bucketPeriod?: 'day'; // In future 'month' | 'year';
+      unit?: 'celsius' | 'fahrenheit' | 'kg' | 'pound';
+    }
+  ): Promise<BucketedRecordsResult>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('HealthConnect');


### PR DESCRIPTION
Initially I thought this wasn't needed however TurboModules is unable to expose the function to it's internal Javascript if we don't specify the type for this. 

I've checked this is working locally and we're now able to pull sleep data. 

https://github.com/user-attachments/assets/41663f67-404b-4b74-a967-bdaf6c192a07

